### PR TITLE
Issue #6: Adding the function 'parseUrlImg'to the app.service

### DIFF
--- a/providers/app.service.ts
+++ b/providers/app.service.ts
@@ -203,4 +203,25 @@ export class AppService implements OnInit {
             }
         }
     }
+
+     /**
+     * parse the url format in PROTOCOL + CDNHOST + UID + NAME=OPTIONAL
+     * to have an url format like that https://ucarecdn.com/6b216114-8e99-4ec4-a64e-874959fade2e/-/resize/500x/photo37544750007.jpg
+     * and no like that https://ucarecdn.com/6b216114-8e99-4ec4-a64e-874959fade2e/photo37544750007.jpg/-/resize/500x/ which brock the cdn url
+     * @param url 
+     */
+    parseUrlImg(url) {
+        let parsedUrl = {};
+        let regex = new RegExp('(https?://)([^:^/]*)(.*/)(.*)$'); //split in PROTOCOL + DOMAIN + UID + FILENAME include .jpg, .png & other format are ckecj by the cdn
+        let found = url.match(regex) // return array and [0] = url
+        
+        parsedUrl = { 
+            protocol: found[1],
+            host: found[2],
+            uid: found[3],
+            filename : !(typeof found[4] === 'undefined' ) ? found[4] : ""
+        }
+        
+        return parsedUrl;
+    }        
 }


### PR DESCRIPTION
## Issue:
In the `Welcome` page, we now use the `logoImg` of the place selected for the Welcome Desk, in order to the user select what place he is having an appointment. To correctly sanitize and process the image as we are doing in the `ionic-app`, I'm including the `parseUrlImg` function into the `app.service.ts` file.