### PR TITLE
Issue #6: Adding an extra check when fd-button is disabled

### DIFF
--- a/components/design-system/fd-button/fd-button.ts
+++ b/components/design-system/fd-button/fd-button.ts
@@ -16,7 +16,7 @@ export class FlitdeskButtonComponent {
   constructor() {}
 
   fdButtonClick(){
-    this.onClick.emit(null);
+    if(!this.disabled) this.onClick.emit(null);
   }
 
 }

--- a/providers/app.service.ts
+++ b/providers/app.service.ts
@@ -12,6 +12,7 @@ export class AppService implements OnInit {
     public isPushwooshOn: boolean = false; // if user is authenticated
     public isTrackingOn: boolean = false; // if user is authenticated
     public translation; // all translations
+    public locale; // default locale to be used for translation of issues and issue categories
     private loading: Loading; // loader
     public mainTabRef: any;
 


### PR DESCRIPTION
## Issue:
According to the issue https://github.com/Norberteam/ionic-app/issues/910, the `fd-button` component wasn't correctly being set as undefined and the function applied to it was still being performed anyways. I added an extra check to the click emitter to avoid this problem.

For the Backoffice, I added a reference for `locale` in the `app.service`, in order to be used for translations of issues and issue categories.