### PR TITLE
Issue #6: Controlling card shadow as a property on fd-card

### DIFF
--- a/components/design-system/fd-card/fd-card.html
+++ b/components/design-system/fd-card/fd-card.html
@@ -1,4 +1,4 @@
-<div class="fd__card" [ngClass]="{ 'card--with-image': image, 'card--with-button': button, 'card--with-top-image': imagePosition && imagePosition === 'top', 'card--with-statusbar': statusbar }">
+<div class="fd__card" [ngClass]="{ 'card--with-image': image, 'card--with-button': button, 'card--with-top-image': imagePosition && imagePosition === 'top', 'card--with-statusbar': statusbar, 'card--with-shadow': shadow }">
   <div class="card__container" (click)="fdCardClick()">
     <ion-icon class="card__chevron" name="norbert-chevron-right" color="primary" *ngIf="chevron"></ion-icon>
     <div class="card__image" [style.background-image]="getImage(image)" [style.height]="getImageSize(imageSize)" *ngIf="image"></div>

--- a/components/design-system/fd-card/fd-card.scss
+++ b/components/design-system/fd-card/fd-card.scss
@@ -9,7 +9,6 @@ fd-card {
         margin-bottom: 16px;
         position: relative;
         transition: background-color .3s;
-        @include app-box-shadow();
 
         &:hover{
             background-color: lighten(color($colors, fd-grey10), 35%);
@@ -197,6 +196,10 @@ fd-card {
                     }
                 }
             }
+        }
+
+        &.card--with-shadow{
+            @include app-box-shadow();
         }
     }
 }

--- a/components/design-system/fd-card/fd-card.ts
+++ b/components/design-system/fd-card/fd-card.ts
@@ -14,6 +14,7 @@ export class FlitdeskCardComponent {
   @Input('button-label') buttonLabel: string;
   @Input('statusbar') statusbar: boolean;
   @Input('statusbar-options') statusbarOptions: FlitDeskCardStatusbarOptions;
+  @Input('shadow') shadow: boolean = true;
   @Output('onClick') onClick: EventEmitter<null> = new EventEmitter();
   @Output('buttonClick') buttonClick: EventEmitter<null> = new EventEmitter();
 

--- a/components/design-system/fd-checkbox/fd-checkbox.html
+++ b/components/design-system/fd-checkbox/fd-checkbox.html
@@ -2,7 +2,7 @@
   <ion-item [ngClass]="{ 'checkbox--right': orientation && orientation === 'right' }">
     <ion-label *ngIf="label && !htmlLabel">{{ label }}</ion-label>
     <ion-checkbox [checked]="checked ? checked : null" [disabled]="disabled ? disabled : null" (ionChange)="toggleCheck()" *ngIf="!orientation || orientation === 'left'"></ion-checkbox>
-    <ion-checkbox item-right [checked]="checked ? checked : null" [disabled]="disabled ? disabled : null" (ionChange)="toggleCheck()" *ngIf="orientation && orientation === 'right'"></ion-checkbox>
+    <ion-checkbox item-right [checked]="checked ? checked : null" [disabled]="disabled ? disabled : null" (ionChange)="toggleCheck($event)" *ngIf="orientation && orientation === 'right'"></ion-checkbox>
   </ion-item>
   <div class="checkbox__custom-label" *ngIf="htmlLabel">
     <ng-content></ng-content>

--- a/components/design-system/fd-checkbox/fd-checkbox.ts
+++ b/components/design-system/fd-checkbox/fd-checkbox.ts
@@ -13,13 +13,18 @@ export class FlitdeskCheckboxComponent extends AbstractValueAcessor<boolean>  {
   @Input('disabled') disabled: boolean;
   @Input('orientation') orientation: string;
   @Output('onChecked') onChecked: EventEmitter<null> = new EventEmitter();
+  @Output('onUnchecked') onUnchecked: EventEmitter<null> = new EventEmitter();
 
   constructor() {
     super();
   }
   
-  toggleCheck(){
-    this.onChecked.emit(null);
+  toggleCheck(event){
+    if(event.value){
+      this.onChecked.emit(null);
+    }else{
+      this.onUnchecked.emit(null);
+    }
   }
 
 }


### PR DESCRIPTION
## Issue:

Adding `shadow` as a property for `fd-card` component, since we'll be using it without it in some scenarios from now on.