### PR TITLE
Issue#6: Adding form validation to fd-textarea component

### DIFF
--- a/components/design-system/fd-textarea/fd-textarea.html
+++ b/components/design-system/fd-textarea/fd-textarea.html
@@ -1,5 +1,11 @@
 <div class="fd__form form__control fd__textarea">
   <ion-textarea
   [placeholder]="placeholder ? placeholder : ''"
-  [attr.rows]="rows ? rows : 6"></ion-textarea>
+  [attr.rows]="rows ? rows : 6"
+  [ngClass]="{ 'textarea--invalid': control && control.invalid && control.dirty }"></ion-textarea>
+  <div class="form__error" *ngIf="control && control.invalid && control.dirty">
+    <div class="error_container" *ngFor="let err of error">
+      <span class="error__message" *ngIf="control.invalid && control.errors[err.type]">{{ err.message }}</span>
+    </div>    
+  </div>
 </div>

--- a/components/design-system/fd-textarea/fd-textarea.scss
+++ b/components/design-system/fd-textarea/fd-textarea.scss
@@ -3,6 +3,7 @@ fd-textarea {
 
     ion-textarea{
         background-color: color($colors, fd-grey05);
+        border: 1px solid transparent;
         border-radius: 5px;
         color: color($colors, fd-grey);
         font-weight: 400;
@@ -22,5 +23,24 @@ fd-textarea {
         &:focus{
             outline: none !important;
         }
+
+        &.textarea--invalid{
+            border-color: color($colors, danger);
+
+            &:hover{
+                border-color: darken(color($colors, danger), 15%);
+            }
+        }        
     }
+
+    .form__error{
+        animation: 1s alertAnim forwards;
+        margin-top: 16px;
+
+        .error__message{
+            color: color($colors, danger);
+            font-size: map-get($fontSizes, xs);
+            font-weight: 300;
+        }
+    }    
 }

--- a/components/design-system/fd-textarea/fd-textarea.ts
+++ b/components/design-system/fd-textarea/fd-textarea.ts
@@ -9,6 +9,8 @@ import { AbstractValueAcessor, MakeProvider } from '../abstract-value-acessor';
 export class FlitdeskTextareaComponent extends AbstractValueAcessor<string> {
   @Input('placeholder') placeholder: string;
   @Input('rows') rows: number;
+  @Input('control') control: any;
+  @Input('error') error: any;
 
   constructor() {
     super();


### PR DESCRIPTION
## Issue:

For the `Visitor app`, I'm adding the same form validation that we have in `fd-input` to `fd-textarea`, handling errors inside the component  and just passing the reference to the form control correspondent.