### PR TITLE
Shared remote service

### DIFF
--- a/providers/auth-service.ts
+++ b/providers/auth-service.ts
@@ -41,6 +41,39 @@ export class AuthService {
     else return null;
   }
 
+  /**
+   * Open web authentification page:
+   * -- Android: open with native browser instance
+   * -- iOs: open with SafariViewController
+   * -- Browser: redirect the user
+   * @param webUrl
+   * @param mobileUrl
+   */
+  openAuthPage(webUrl: string, mobileUrl: string, nodeEnv: string) {
+    let url: string;
+    if (this.platform.is('core') || this.platform.is('mobileweb')) { // Web case
+      console.log('Web case calling');
+      url = webUrl;
+    } else { // Mobile case
+      console.log('Mobile case url');
+      url = mobileUrl;
+      if (nodeEnv === 'localDev')
+        url = `https://localhost:3000${mobileUrl}`;
+    }
+    if (this.platform.is('ios')) {
+      this.openUrlSafariController(url);
+    } else {
+      this.openUrlInAppWebBrowser(url);
+    }
+  }
+
+  /*
+    Check if login needs being bypassed
+  */
+  isBypassLoginEnabled(constants) {
+    return constants.BYPASS_LOGIN && constants.NODE_ENV === 'localDev';
+  }
+
   getUserProfile() {
     return this.appLocalStorageService.get(Constants.LS['USER']);
   }

--- a/providers/remote-service.ts
+++ b/providers/remote-service.ts
@@ -1,0 +1,24 @@
+import { Constants } from './../../src/app/app.constants';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+/*
+  Generated class for the QrCodeProvider provider.
+
+  See https://angular.io/guide/dependency-injection for more info on providers
+  and Angular DI.
+*/
+@Injectable()
+export class SharedRemoteService {
+    // TODO Issue #296: Use environments to manage different versions of APIs
+    getApiUrl: string = Constants.API_URL;
+
+    constructor(public http: HttpClient) {
+    }
+
+    developmentLogin(provider: string, userType: string) {
+        return this.http.post(`${this.getApiUrl}`+ '/users/dev-login', {
+            provider, userType
+        });
+    }
+}


### PR DESCRIPTION
Fix #56 

Linked to [Visitor PR](https://github.com/Norberteam/visitor-app/pull/104)

To implement **login bypass** for `visitor`, I noticed some of the functions would be potentially shared among our project, so I moved them here, along with creating a `SharedRemoteService` where to include all network calls that are shared among our front-end projects